### PR TITLE
Some tweaking

### DIFF
--- a/src/TablestoreLock.php
+++ b/src/TablestoreLock.php
@@ -31,9 +31,9 @@ final class TablestoreLock extends Lock
      */
     public function acquire()
     {
-        return $this->tablestore->add(
-            $this->name, $this->owner, $this->seconds
-        );
+        $seconds = $this->seconds > 0 ? $this->seconds : 86400;
+
+        return $this->tablestore->add($this->name, $this->owner, $seconds);
     }
 
     /**

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -81,11 +81,10 @@ final class TablestoreStore implements LockProvider, Store
             return [];
         }
 
-        $now = Carbon::now()->getTimestampMs();
-
-        $response = $this->tablestore->batch(function ($query) use ($keys, $now) {
-            $query->table($this->table)
-                ->where($this->expirationAttribute, '>', $now);
+        $response = $this->tablestore->batch(function ($query) use ($keys) {
+            $query->table($this->table)->where(
+                $this->expirationAttribute, '>', Carbon::now()->getTimestampMs()
+            );
 
             foreach ($keys as $key) {
                 $query->table($this->table)

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -191,7 +191,7 @@ final class TablestoreStore implements LockProvider, Store
             $filter->setType(FilterType::FT_SINGLE_COLUMN_VALUE);
             $filter->setFilter((new SingleColumnValueFilter)
                 ->setColumnName($this->expirationAttribute)
-                ->setComparator(ComparatorType::CT_LESS_THAN)
+                ->setComparator(ComparatorType::CT_LESS_EQUAL)
                 ->setColumnValue($now->getBuffer())
                 ->setFilterIfMissing(false) // allow missing
                 ->setLatestVersionOnly(true)

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -152,6 +152,10 @@ final class TablestoreStore implements LockProvider, Store
      */
     public function putMany(array $values, $seconds)
     {
+        if ($values === []) {
+            return true;
+        }
+
         $expiration = $this->toTimestamp($seconds);
 
         $this->tablestore->batch(function ($query) use ($values, $expiration) {

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -54,7 +54,7 @@ final class TablestoreStore implements LockProvider, Store
     {
         $item = $this->tablestore->table($this->table)
             ->whereKey($this->keyAttribute, $this->prefix.$key)
-            ->where($this->expirationAttribute, '>', Carbon::now()->getTimestampMs())
+            ->where($this->expirationAttribute, '>', Carbon::now()->getTimestamp())
             ->get()->getDecodedRow();
 
         if ($item === null) {
@@ -83,7 +83,7 @@ final class TablestoreStore implements LockProvider, Store
 
         $response = $this->tablestore->batch(function ($query) use ($keys) {
             $query->table($this->table)->where(
-                $this->expirationAttribute, '>', Carbon::now()->getTimestampMs()
+                $this->expirationAttribute, '>', Carbon::now()->getTimestamp()
             );
 
             foreach ($keys as $key) {
@@ -182,7 +182,7 @@ final class TablestoreStore implements LockProvider, Store
     public function add($key, $value, $seconds)
     {
         try {
-            Attribute::integer($this->expirationAttribute, Carbon::now()->getTimestampMs())
+            Attribute::integer($this->expirationAttribute, Carbon::now()->getTimestamp())
                 ->toFormattedValue($now = new PlainbufferWriter);
 
             // Include only items that do not exist or that have expired
@@ -229,7 +229,7 @@ final class TablestoreStore implements LockProvider, Store
             $this->tablestore->table($this->table)
                 ->whereKey($this->keyAttribute, $this->prefix.$key)
                 ->expectExists()
-                ->where($this->expirationAttribute, '>', Carbon::now()->getTimestampMs())
+                ->where($this->expirationAttribute, '>', Carbon::now()->getTimestamp())
                 ->update([
                     Attribute::increment($this->valueAttribute, $value),
                 ]);
@@ -257,7 +257,7 @@ final class TablestoreStore implements LockProvider, Store
             $this->tablestore->table($this->table)
                 ->whereKey($this->keyAttribute, $this->prefix.$key)
                 ->expectExists()
-                ->where($this->expirationAttribute, '>', Carbon::now()->getTimestampMs())
+                ->where($this->expirationAttribute, '>', Carbon::now()->getTimestamp())
                 ->update([
                     Attribute::decrement($this->valueAttribute, $value),
                 ]);
@@ -281,7 +281,7 @@ final class TablestoreStore implements LockProvider, Store
      */
     public function forever($key, $value)
     {
-        return $this->put($key, $value, Carbon::now()->addYears(5)->getTimestampMs());
+        return $this->put($key, $value, Carbon::now()->addYears(5)->getTimestamp());
     }
 
     /**
@@ -387,15 +387,13 @@ final class TablestoreStore implements LockProvider, Store
     }
 
     /**
-     * Get the UNIX timestamp in milliseconds for the given number of seconds.
+     * Get the UNIX timestamp for the given number of seconds.
      */
     private function toTimestamp(int $seconds): int
     {
-        $timestamp = $seconds > 0
+        return $seconds > 0
             ? $this->availableAt($seconds)
             : Carbon::now()->getTimestamp();
-
-        return $timestamp * 1000;
     }
 
     /**

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -229,6 +229,7 @@ final class TablestoreStore implements LockProvider, Store
             $this->tablestore->table($this->table)
                 ->whereKey($this->keyAttribute, $this->prefix.$key)
                 ->expectExists()
+                ->where($this->expirationAttribute, '>', Carbon::now()->getTimestampMs())
                 ->update([
                     Attribute::increment($this->valueAttribute, $value),
                 ]);
@@ -256,13 +257,14 @@ final class TablestoreStore implements LockProvider, Store
             $this->tablestore->table($this->table)
                 ->whereKey($this->keyAttribute, $this->prefix.$key)
                 ->expectExists()
+                ->where($this->expirationAttribute, '>', Carbon::now()->getTimestampMs())
                 ->update([
                     Attribute::decrement($this->valueAttribute, $value),
                 ]);
 
             return true;
         } catch (TablestoreException $e) {
-            if ($e->getError()->getCode() === 'ConditionalCheckFailed') {
+            if ($e->getError()->getCode() === 'OTSConditionCheckFail') {
                 return false;
             }
 

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -52,12 +52,10 @@ final class TablestoreStore implements LockProvider, Store
      */
     public function get($key)
     {
-        $response = $this->tablestore->table($this->table)
+        $item = $this->tablestore->table($this->table)
             ->whereKey($this->keyAttribute, $this->prefix.$key)
             ->where($this->expirationAttribute, '>', Carbon::now()->getTimestampMs())
-            ->get();
-
-        $item = $response->getDecodedRow();
+            ->get()->getDecodedRow();
 
         if ($item === null) {
             return;
@@ -66,11 +64,7 @@ final class TablestoreStore implements LockProvider, Store
         /** @var \Dew\Tablestore\Contracts\HasValue[] */
         $values = $item[$this->valueAttribute] ?? [];
 
-        if (! isset($values[0])) {
-            return;
-        }
-
-        return $this->unserialize($values[0]->value());
+        return isset($values[0]) ? $this->unserialize($values[0]->value()) : null;
     }
 
     /**

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -102,17 +102,17 @@ final class TablestoreStore implements LockProvider, Store
         $rows = $tables[0]->getRows();
 
         foreach ($rows as $row) {
-            $decoded = (new RowDecodableResponse($row))->getDecodedRow();
+            $item = (new RowDecodableResponse($row))->getDecodedRow();
 
-            if ($decoded === null) {
+            if ($item === null) {
                 continue;
             }
 
             /** @var \Dew\Tablestore\Cells\StringPrimaryKey */
-            $key = $decoded[$this->keyAttribute];
+            $key = $item[$this->keyAttribute];
 
             /** @var \Dew\Tablestore\Contracts\HasValue[] */
-            $values = $decoded[$this->valueAttribute] ?? [];
+            $values = $item[$this->valueAttribute] ?? [];
 
             if (isset($values[0])) {
                 $result[$this->pure($key->value())] = $this->unserialize(

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -84,10 +84,12 @@ final class TablestoreStore implements LockProvider, Store
         $now = Carbon::now()->getTimestampMs();
 
         $response = $this->tablestore->batch(function ($query) use ($keys, $now) {
+            $query->table($this->table)
+                ->where($this->expirationAttribute, '>', $now);
+
             foreach ($keys as $key) {
                 $query->table($this->table)
                     ->whereKey($this->keyAttribute, $this->prefix.$key)
-                    ->where($this->expirationAttribute, '>', $now)
                     ->get();
             }
         });

--- a/src/TablestoreStore.php
+++ b/src/TablestoreStore.php
@@ -77,6 +77,10 @@ final class TablestoreStore implements LockProvider, Store
      */
     public function many(array $keys)
     {
+        if ($keys === []) {
+            return [];
+        }
+
         $now = Carbon::now()->getTimestampMs();
 
         $response = $this->tablestore->batch(function ($query) use ($keys, $now) {

--- a/tests/TablestoreStoreTest.php
+++ b/tests/TablestoreStoreTest.php
@@ -90,8 +90,11 @@ class TablestoreStoreTest extends TestCase
     {
         $key = Str::random(6);
 
-        $this->assertTrue(Cache::driver('tablestore')->add($key, 'Zhineng', 10));
-        $this->assertFalse(Cache::driver('tablestore')->add($key, 'Zhineng', 10));
+        $this->assertTrue(Cache::driver('tablestore')->add($key, 'Zhineng', 5));
+        $this->assertFalse(Cache::driver('tablestore')->add($key, 'Zhineng', 5));
+
+        sleep(5);
+        $this->assertTrue(Cache::driver('tablestore')->add($key, 'Zhineng', 5));
     }
 
     public function test_items_can_be_incremented_and_decremented()

--- a/tests/TablestoreStoreTest.php
+++ b/tests/TablestoreStoreTest.php
@@ -109,6 +109,13 @@ class TablestoreStoreTest extends TestCase
         $this->assertSame(0, Cache::driver('tablestore')->get('counter'));
     }
 
+    public function test_incrementing_and_decrementing_should_respect_expiration()
+    {
+        Cache::driver('tablestore')->getStore()->put('counter', 5, 0);
+        $this->assertFalse(Cache::driver('tablestore')->increment('counter'));
+        $this->assertFalse(Cache::driver('tablestore')->decrement('counter'));
+    }
+
     public function test_locks_can_be_acquired()
     {
         Cache::driver('tablestore')->lock('lock', 10)->get(function () {

--- a/tests/TablestoreStoreTest.php
+++ b/tests/TablestoreStoreTest.php
@@ -61,6 +61,11 @@ class TablestoreStoreTest extends TestCase
         $this->assertSame($result, $items);
     }
 
+    public function test_items_can_be_returned_early_if_keys_are_empty()
+    {
+        $this->assertSame([], Cache::driver('tablestore')->many([]));
+    }
+
     public function test_items_not_found_will_have_a_null_value()
     {
         $this->assertNull(Cache::driver('tablestore')->get('not-exists-1'));

--- a/tests/TablestoreStoreTest.php
+++ b/tests/TablestoreStoreTest.php
@@ -66,6 +66,11 @@ class TablestoreStoreTest extends TestCase
         $this->assertSame([], Cache::driver('tablestore')->many([]));
     }
 
+    public function test_items_can_be_returned_early_when_saving_if_values_are_empty()
+    {
+        $this->assertTrue(Cache::driver('tablestore')->putMany([], 10));
+    }
+
     public function test_items_not_found_will_have_a_null_value()
     {
         $this->assertNull(Cache::driver('tablestore')->get('not-exists-1'));


### PR DESCRIPTION
- The lock acquires 1 day by default.
- Use timestamp instead of timestampMs for the expiration attribute.
- Handle multiple key retrieval `many` when keys are empty.
- Handle multiple key persistence `putMany` when values are empty.
- Fix incrementing and decrementing did not respect expiration.