### PR TITLE
Replace deprecated SDK

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,4 +59,3 @@ jobs:
           ACS_ACCESS_KEY_SECRET: ${{ secrets.ACS_ACCESS_KEY_SECRET }}
           TABLESTORE_ENDPOINT: ${{ secrets.TABLESTORE_ENDPOINT }}
           TABLESTORE_TABLE: ${{ secrets.TABLESTORE_TABLE }}
-

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^7.37|^8.17",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "php-http/guzzle7-adapter": "^1.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "dew-serverless/acs-sdk-php": "^0.2.0"
+        "dew-serverless/acs-sdk-php": "^0.2.0",
+        "google/protobuf": "^4.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.37|^8.17",

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,11 @@
         "google/protobuf": "^4.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.0",
         "orchestra/testbench": "^7.37|^8.17",
+        "php-http/guzzle7-adapter": "^1.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "laravel/pint": "^1.0",
         "rector/rector": "^0.18.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,8 @@
             "@lint",
             "@test:integration"
         ]
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "dew-serverless/tablestore-php": "^1.1"
+        "dew-serverless/acs-sdk-php": "^0.2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.37|^8.17",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "dew-serverless/acs-sdk-php": "^0.2.0",
         "google/protobuf": "^4.0"
     },

--- a/src/TablestoreServiceProvider.php
+++ b/src/TablestoreServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dew\TablestoreDriver;
 
-use Dew\Tablestore\Tablestore;
+use Dew\Acs\Tablestore\TablestoreInstance;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,18 +29,15 @@ final class TablestoreServiceProvider extends ServiceProvider
     private function registerCacheDriver(): void
     {
         Cache::extend('tablestore', function ($app, $config) {
-            $client = new Tablestore(
-                $config['key'], $config['secret'],
-                $config['endpoint'], $config['instance'] ?? null
-            );
-
-            if (isset($config['token'])) {
-                $client->tokenUsing($config['token']);
-            }
-
-            if (isset($config['http'])) {
-                $client->optionsUsing($config['http']);
-            }
+            $client = new TablestoreInstance([
+                'credentials' => [
+                    'key' => $config['key'],
+                    'secret' => $config['secret'],
+                    'token' => $config['token'] ?? null,
+                ],
+                'instance' => $config['instance'] ?? null,
+                'endpoint' => $config['endpoint'],
+            ]);
 
             return Cache::repository(
                 new TablestoreStore(


### PR DESCRIPTION
This PR replaces the deprecated _Tablestore_ SDK with the `acs-sdk-php` package.